### PR TITLE
Support legacy network data formats with automatic osmid remapping

### DIFF
--- a/LivingCity/roadGraphB2018Loader.cpp
+++ b/LivingCity/roadGraphB2018Loader.cpp
@@ -127,8 +127,9 @@ void RoadGraphB2018::loadB2018RoadGraph(RoadGraph &inRoadGraph, QString networkP
   const int indexX = headers.indexOf("x");
   const int indexY = headers.indexOf("y");
   const int indexHigh = headers.indexOf("highway");
-  const int indexNodeIndex = headers.indexOf("index"); // the normalized index used to identify nodes across the code
+  const int indexNodeIndex = headers.indexOf("index"); // optional: sequential if missing
 
+  uint64_t autoIndex = 0;
   while (!stream.atEnd()) {
     line = stream.readLine();
     QStringList fields = line.split(',', QString::SkipEmptyParts);
@@ -140,8 +141,10 @@ void RoadGraphB2018::loadB2018RoadGraph(RoadGraph &inRoadGraph, QString networkP
 
     float x = fields[indexX].toFloat();
     float y = fields[indexY].toFloat();
-    //qDebug() << "x " << x << " y " << y;
-    uint64_t nodeIndex = fields[indexNodeIndex].toLongLong();
+    uint64_t nodeIndex = (indexNodeIndex >= 0 && indexNodeIndex < fields.size())
+                         ? fields[indexNodeIndex].toLongLong()
+                         : autoIndex;
+    autoIndex++;
     nodeIndexToVertexLoc[nodeIndex] = QVector2D(x, y);
     updateMinMax2(QVector2D(x, y), minBox, maxBox);
 
@@ -378,12 +381,9 @@ void RoadGraphB2018::loadABMGraph(
   std::cout << nodeFileName << " as nodes file\n";
 
   auto start = high_resolution_clock::now();
-  //EDGES
-  graph_->read_graph_osm(edgeFileName);
-  //printf("# of edges: %d\n", graph_->nedges());
-  
-  //NODES
+  // Load vertices first so the osmid→index map is available for edge loading
   graph_->read_vertices(nodeFileName);
+  graph_->read_graph_osm(edgeFileName);
   
   auto stop = high_resolution_clock::now();
   auto duration = duration_cast<milliseconds>(stop - start);

--- a/LivingCity/traffic/b18TrafficSP.cpp
+++ b/LivingCity/traffic/b18TrafficSP.cpp
@@ -1,6 +1,8 @@
 #include "b18TrafficSP.h"
 
 #include <boost/graph/exterior_property.hpp>
+#include <fstream>
+#include <algorithm>
 #include "src/linux_host_memory_logger.h"
 #include "roadGraphB2018Loader.h"
 #include "accessibility.h"
@@ -92,29 +94,50 @@ void B18TrafficSP::read_od_pairs_from_structure(
   }
 }
 
-// Read OD pairs file format
+// Read OD pairs file format — supports both:
+//   New format: dep_time, origin, destination
+//   Legacy format: SAMPN, PERNO, origin, destination (dep_time generated uniformly)
 std::vector<std::array<abm::graph::vertex_t, 2>> B18TrafficSP::read_od_pairs_from_file(
   const std::string& filename,
   const float startSimulationH,
   const float endSimulationH,
   const int nagents) {
   std::vector<std::array<abm::graph::vertex_t, 2>> od_pairs;
-  csvio::CSVReader<3> in(filename);
-  in.read_header(csvio::ignore_extra_column, "dep_time", "origin", "destination");
+
+  // Detect format
+  std::ifstream probe(filename);
+  std::string headerLine;
+  std::getline(probe, headerLine);
+  probe.close();
+  bool hasDepTime = (headerLine.find("dep_time") != std::string::npos);
+
   abm::graph::vertex_t v1, v2;
-  abm::graph::weight_t weight;
-  float dep_time;
   int count_outside_filter = 0;
-  while (in.read_row(dep_time, v1, v2)) {
-    if (dep_time >= startSimulationH * 3600 && dep_time < endSimulationH * 3600){
-      std::array<abm::graph::vertex_t, 2> od = {v1, v2};
-      od_pairs.emplace_back(od);
-      RoadGraphB2018::demandB2018.push_back(DemandB2018(1, v1, v2)); //there is only one person for each OD pair
-    } else {
-      count_outside_filter++;
+
+  if (hasDepTime) {
+    csvio::CSVReader<3> in(filename);
+    in.read_header(csvio::ignore_extra_column, "dep_time", "origin", "destination");
+    float dep_time;
+    while (in.read_row(dep_time, v1, v2)) {
+      if (dep_time >= startSimulationH * 3600 && dep_time < endSimulationH * 3600) {
+        od_pairs.push_back({v1, v2});
+        RoadGraphB2018::demandB2018.push_back(DemandB2018(1, v1, v2));
+      } else {
+        count_outside_filter++;
+      }
+    }
+  } else {
+    // Legacy format — all trips are within the simulation window
+    csvio::CSVReader<4> in(filename);
+    in.read_header(csvio::ignore_extra_column, "SAMPN", "PERNO", "origin", "destination");
+    int sampn, perno;
+    while (in.read_row(sampn, perno, v1, v2)) {
+      od_pairs.push_back({v1, v2});
+      RoadGraphB2018::demandB2018.push_back(DemandB2018(1, v1, v2));
     }
   }
-  if (count_outside_filter > 0){
+
+  if (count_outside_filter > 0) {
     std::cout << "WARNING: Filtering " << count_outside_filter << " trips outside the input time range." << std::endl;
   }
   RoadGraphB2018::totalNumPeople = RoadGraphB2018::demandB2018.size();
@@ -123,25 +146,53 @@ std::vector<std::array<abm::graph::vertex_t, 2>> B18TrafficSP::read_od_pairs_fro
   return od_pairs;
 }
 
-// Read OD pairs file format
+// Read departure times — generates uniform distribution if dep_time column missing
 std::vector<float> B18TrafficSP::read_dep_times(
   const std::string& filename,
   const float startSimulationH,
   const float endSimulationH) {
   std::vector<float> dep_time_vec;
-  csvio::CSVReader<1> in(filename);
-  in.read_header(csvio::ignore_extra_column, "dep_time");
-  float dep_time;
-  int count_outside_filter = 0;
-  while (in.read_row(dep_time)) {
-    if (dep_time >= startSimulationH * 3600 && dep_time < endSimulationH * 3600){
-      dep_time_vec.emplace_back(dep_time);
-    } else {
-      count_outside_filter++;
+
+  std::ifstream probe(filename);
+  std::string headerLine;
+  std::getline(probe, headerLine);
+  probe.close();
+  bool hasDepTime = (headerLine.find("dep_time") != std::string::npos);
+
+  if (hasDepTime) {
+    csvio::CSVReader<1> in(filename);
+    in.read_header(csvio::ignore_extra_column, "dep_time");
+    float dep_time;
+    int count_outside_filter = 0;
+    while (in.read_row(dep_time)) {
+      if (dep_time >= startSimulationH * 3600 && dep_time < endSimulationH * 3600) {
+        dep_time_vec.emplace_back(dep_time);
+      } else {
+        count_outside_filter++;
+      }
     }
-  }
-  if (count_outside_filter > 0) {
-    std::cout << "WARNING: Filtering " << count_outside_filter << " trips outside the input time range." << std::endl;
+    if (count_outside_filter > 0) {
+      std::cout << "WARNING: Filtering " << count_outside_filter << " trips outside the input time range." << std::endl;
+    }
+  } else {
+    // No dep_time column — generate uniform departure times across the window
+    // Count lines to know how many trips there are
+    std::ifstream countFile(filename);
+    std::string line;
+    std::getline(countFile, line); // skip header
+    int numTrips = 0;
+    while (std::getline(countFile, line)) {
+      if (!line.empty()) numTrips++;
+    }
+    countFile.close();
+    float startSec = startSimulationH * 3600.0f;
+    float endSec = endSimulationH * 3600.0f;
+    float step = (endSec - startSec) / std::max(numTrips, 1);
+    for (int i = 0; i < numTrips; i++) {
+      dep_time_vec.emplace_back(startSec + step * i);
+    }
+    std::cout << "Generated " << numTrips << " synthetic departure times in ["
+              << startSimulationH << "h, " << endSimulationH << "h)" << std::endl;
   }
   return dep_time_vec;
 }

--- a/LivingCity/traffic/sp/graph.cc
+++ b/LivingCity/traffic/sp/graph.cc
@@ -1,5 +1,6 @@
 #include "graph.h"
 #include <string>
+#include <fstream>
 #include <cassert>
 
 inline void abm::Graph::add_edge(const graph::vertex_t vertex_from, const graph::vertex_t vertex_to,
@@ -148,38 +149,80 @@ bool abm::Graph::read_graph_matrix_market(const std::string& filename) {
   return status;
 }
 */
-// Read MatrixMarket graph file format
+// Read graph edges from CSV — supports both the 8-column format
+// (uniqueid, osmid_u, osmid_v, length, lanes, speed_mph, u, v)
+// and the legacy 6-column format (uniqueid, u, v, length, lanes, speed_mph).
 bool abm::Graph::read_graph_osm(const std::string& filename) {
   bool status = true;
   std::cout << "reading graph osm" << std::endl;
+
+  // Detect format from header
+  std::ifstream probe(filename);
+  std::string headerLine;
+  std::getline(probe, headerLine);
+  probe.close();
+  bool hasOsmidColumns = (headerLine.find("osmid_u") != std::string::npos);
+
   try {
-    csvio::CSVReader<8> in(filename);
-    in.read_header(csvio::ignore_extra_column, "uniqueid", "osmid_u", "osmid_v", "length", "lanes", "speed_mph", "u", "v");
     abm::graph::vertex_t nvertices = 0;
     float length, lanes, speed_mph;
     abm::graph::vertex_t index = 0;
     abm::graph::edge_id_t edgeid;
-    abm::graph::vertex_t osmid_v1, osmid_v2, v1, v2;
-    while (in.read_row(edgeid, osmid_v1, osmid_v2, length, lanes, speed_mph, v1, v2)) {
-      // todo: create a function for the following conversion
-	    float max_speed_limit_mps = ( speed_mph / 3600 ) * 1609.34; //convert from mph to meters/second
+    abm::graph::vertex_t v1, v2;
 
-      //Don't add if there is already an edge with the same vertices
-      if (edges_.find(std::make_pair(v1, v2)) == edges_.end()) {
-        if (this->edge_ids_.size() <= v1){
-          std::cout << v1 << " is bigger than the size, which is " << this->edge_ids_.size() << std::endl;
+    if (hasOsmidColumns) {
+      csvio::CSVReader<8> in(filename);
+      in.read_header(csvio::ignore_extra_column, "uniqueid", "osmid_u", "osmid_v", "length", "lanes", "speed_mph", "u", "v");
+      abm::graph::vertex_t osmid_v1, osmid_v2;
+      while (in.read_row(edgeid, osmid_v1, osmid_v2, length, lanes, speed_mph, v1, v2)) {
+        float max_speed_limit_mps = (speed_mph / 3600.0f) * 1609.34f;
+        if (edges_.find(std::make_pair(v1, v2)) == edges_.end()) {
+          this->add_edge(v1, v2, length, lanes, max_speed_limit_mps, edgeid);
         }
-        this->add_edge(v1, v2, length, lanes, max_speed_limit_mps, edgeid);
+        ++nvertices;
+        edge_vertex_map_[v1] = index;
+        ++index;
       }
-      ++nvertices;
+    } else {
+      // Legacy 6-column format: u/v are osmids that need mapping to sequential indices.
+      // Build osmid→index map from nodeIndex_to_osmid_ (populated by read_vertices)
+      std::unordered_map<abm::graph::vertex_t, abm::graph::vertex_t> osmid_to_idx;
+      for (size_t i = 0; i < nodeIndex_to_osmid_.size(); i++) {
+        abm::graph::vertex_t osmid = nodeIndex_to_osmid_[i];
+        if (osmid != 0) {
+          osmid_to_idx[osmid] = i;
+        }
+      }
+      std::cout << "Built osmid->index map with " << osmid_to_idx.size() << " entries" << std::endl;
 
-      //map edge vertex ids to smaller values
-      edge_vertex_map_[v1] = index;
-      //std::cout << "v1 map = " << edge_vertex_map_[v1] << "\n";
-      ++index;
+      csvio::CSVReader<6> in(filename);
+      in.read_header(csvio::ignore_extra_column, "uniqueid", "u", "v", "length", "lanes", "speed_mph");
+      abm::graph::vertex_t raw_v1, raw_v2;
+      while (in.read_row(edgeid, raw_v1, raw_v2, length, lanes, speed_mph)) {
+        // Map osmid to sequential index if needed
+        v1 = raw_v1;
+        v2 = raw_v2;
+        if (v1 >= this->edge_ids_.size() && osmid_to_idx.count(raw_v1)) {
+          v1 = osmid_to_idx[raw_v1];
+        }
+        if (v2 >= this->edge_ids_.size() && osmid_to_idx.count(raw_v2)) {
+          v2 = osmid_to_idx[raw_v2];
+        }
+        if (v1 >= this->edge_ids_.size() || v2 >= this->edge_ids_.size()) {
+          continue; // skip edges with unmappable vertices
+        }
+        float max_speed_limit_mps = (speed_mph / 3600.0f) * 1609.34f;
+        if (edges_.find(std::make_pair(v1, v2)) == edges_.end()) {
+          this->add_edge(v1, v2, length, lanes, max_speed_limit_mps, edgeid);
+        }
+        ++nvertices;
+        edge_vertex_map_[v1] = index;
+        ++index;
+      }
     }
+
     std::cout << "total edges = " << index << "\n";
-    this-> max_edge_id_=index;
+    this->max_edge_id_ = index;
     this->assign_nvertices(nvertices);
     std::cout << "# of edges: " << this->edges_.size() << "\n";
 
@@ -192,36 +235,56 @@ bool abm::Graph::read_graph_osm(const std::string& filename) {
 }
 
 bool abm::Graph::read_vertices(const std::string& filename) {
-	QVector2D minBox(FLT_MAX, FLT_MAX);
-	QVector2D maxBox(-FLT_MAX, -FLT_MAX);
-	  float scale = 1.0f;
-	  float sqSideSz = std::max<float>(maxBox.x() - minBox.x(),
-				    maxBox.y() - minBox.y()) * scale * 0.5f; // half side
-	  QVector3D centerV(-minBox.x(), -minBox.y(), 0);
-	  QVector3D centerAfterSc(-sqSideSz, -sqSideSz, 0);
+  QVector2D minBox(FLT_MAX, FLT_MAX);
+  QVector2D maxBox(-FLT_MAX, -FLT_MAX);
+  float scale = 1.0f;
+  float sqSideSz = std::max<float>(maxBox.x() - minBox.x(),
+                                   maxBox.y() - minBox.y()) * scale * 0.5f;
+  QVector3D centerV(-minBox.x(), -minBox.y(), 0);
+  QVector3D centerAfterSc(-sqSideSz, -sqSideSz, 0);
   bool status = true;
-  csvio::CSVReader<6> in(filename);
-  in.read_header(csvio::ignore_extra_column, "osmid", "x", "y", "ref", "highway", "index");
+
+  // Detect whether the CSV has an "index" column by reading the header line
+  std::ifstream probe(filename);
+  std::string headerLine;
+  std::getline(probe, headerLine);
+  probe.close();
+  bool hasIndex = (headerLine.find("index") != std::string::npos);
+
   float lat, lon;
   abm::graph::vertex_t nodeIndex, osmid;
   std::string ref, highway;
 
-  while (in.read_row(osmid, lat, lon, ref, highway, nodeIndex)) {
-    //std::cout << "osmid = " << osmid << "\n";
-    //std::cout << "nodeIndex = " << nodeIndex << "\n";
-
-    this->nodeIndex_to_osmid_[nodeIndex] = osmid;
-    QVector3D pos(lat, lon, 0);
-    pos += centerV;//center
-    pos *= scale;
-    pos += centerAfterSc;
-    pos.setX(pos.x() * -1.0f); // seems vertically rotated
-    vertices_data_[nodeIndex] = pos;
+  if (hasIndex) {
+    csvio::CSVReader<6> in(filename);
+    in.read_header(csvio::ignore_extra_column, "osmid", "x", "y", "ref", "highway", "index");
+    while (in.read_row(osmid, lat, lon, ref, highway, nodeIndex)) {
+      this->nodeIndex_to_osmid_[nodeIndex] = osmid;
+      QVector3D pos(lat, lon, 0);
+      pos += centerV;
+      pos *= scale;
+      pos += centerAfterSc;
+      pos.setX(pos.x() * -1.0f);
+      vertices_data_[nodeIndex] = pos;
+    }
+  } else {
+    // No index column — assign sequential indices based on row order
+    csvio::CSVReader<5> in(filename);
+    in.read_header(csvio::ignore_extra_column, "osmid", "x", "y", "ref", "highway");
+    abm::graph::vertex_t autoIndex = 0;
+    while (in.read_row(osmid, lat, lon, ref, highway)) {
+      nodeIndex = autoIndex++;
+      this->nodeIndex_to_osmid_[nodeIndex] = osmid;
+      QVector3D pos(lat, lon, 0);
+      pos += centerV;
+      pos *= scale;
+      pos += centerAfterSc;
+      pos.setX(pos.x() * -1.0f);
+      vertices_data_[nodeIndex] = pos;
+    }
   }
-  
+
   std::cout << "# of vertices: " << vertices_data_.size() << "\n";
-
-
   return status;
 }
 

--- a/LivingCity/traffic/sp/graph.h
+++ b/LivingCity/traffic/sp/graph.h
@@ -47,17 +47,30 @@ class Graph {
   explicit Graph(bool directed, std::string networkPath) {
     this->directed_ = directed;
 
-    // --- we get the max vertex id
+    // --- we get the max vertex id (or count lines if no index column)
     const std::string& nodeFileName = networkPath + "nodes.csv";
-    csvio::CSVReader<1> inMaxVertexIndex(nodeFileName);
-    inMaxVertexIndex.read_header(csvio::ignore_extra_column, "index");
     abm::graph::vertex_t osmid, nodeIndex;
     std::string ref;
     std::string highway;
     float lat, lon;
     abm::graph::vertex_t maxVertexIndexFound = 0;
-    while (inMaxVertexIndex.read_row(nodeIndex)) {
-      maxVertexIndexFound = std::max(nodeIndex, maxVertexIndexFound);
+    {
+      std::ifstream probe(nodeFileName);
+      std::string hdr;
+      std::getline(probe, hdr);
+      if (hdr.find("index") != std::string::npos) {
+        csvio::CSVReader<1> inMaxVertexIndex(nodeFileName);
+        inMaxVertexIndex.read_header(csvio::ignore_extra_column, "index");
+        while (inMaxVertexIndex.read_row(nodeIndex)) {
+          maxVertexIndexFound = std::max(nodeIndex, maxVertexIndexFound);
+        }
+      } else {
+        // No index column — count rows to determine max vertex id
+        std::string line;
+        while (std::getline(probe, line)) {
+          if (!line.empty()) maxVertexIndexFound++;
+        }
+      }
     }
     this->edge_ids_ = std::vector<tsl::robin_map<graph::vertex_t, graph::edge_id_t>>(maxVertexIndexFound+1);
     this->nodeIndex_to_osmid_ = std::vector<graph::vertex_t>(maxVertexIndexFound+1);


### PR DESCRIPTION
Closes #49

## Summary

Makes the simulator work with the bundled `berkeley_2018/full_network/` data out of the box:

- **nodes.csv**: auto-generates sequential index if `index` column missing
- **edges.csv**: auto-detects 6-col vs 8-col format; builds osmid→index map and remaps edge endpoints
- **od_demand.csv**: supports legacy `SAMPN,PERNO,origin,dest` format; generates uniform synthetic departure times
- **Load order**: vertices loaded before edges so osmid map is available

## Verification

```
# of vertices: 223328
Built osmid->index map with 223328 entries
total edges = 547697
# of edges: 540827
# of OD pairs = 10219
Generated 10219 synthetic departure times in [5h, 6h)
Lane map created (1.2 GB, 1,081,654 lanes)
```

Full pipeline runs through lane map creation. GPU simulation requires actual hardware.

## Test plan

- [x] Build: zero errors in CUDA 12.4 Docker
- [x] Data loading: verified all 3 legacy files parse correctly
- [x] Lane map creation: completes without crash
- [ ] Full simulation: needs GPU hardware