### PR TITLE
Implement vertiport capacity modeling with pad queueing

### DIFF
--- a/LivingCity/traffic/b18CUDA_trafficSimulator.cu
+++ b/LivingCity/traffic/b18CUDA_trafficSimulator.cu
@@ -2003,7 +2003,15 @@ __global__ void kernel_intersectionOneSimulation(
   // if(blockIdx.x>218)printf("blockIdx: %d",blockIdx.x);
   int i = blockIdx.x * blockDim.x + threadIdx.x;
   if(i<numIntersections){//CUDA check (inside margins)
-    const float deltaEvent = 20.0f; /// !!!!
+    // Vertiport capacity management: release pads after turnover time
+    if (intersections[i].isVertiport && intersections[i].vertiportCurrentOccupancy > 0) {
+      if (currentTime - intersections[i].vertiportLastDepartureTime >= intersections[i].vertiportTurnoverTimeSec) {
+        intersections[i].vertiportCurrentOccupancy--;
+        intersections[i].vertiportLastDepartureTime = currentTime;
+      }
+    }
+
+    const float deltaEvent = 20.0f;
     if (currentTime > intersections[i].nextEvent && intersections[i].totalInOutEdges > 0) {
 
       uint edgeOT = intersections[i].edge[intersections[i].state];
@@ -2027,8 +2035,19 @@ __global__ void kernel_intersectionOneSimulation(
           uchar numLinesI = edgeIT >> 24;
 
           for (int nL = 0; nL < numLinesI; nL++) {
-            if (intersections[i].isVertiport) trafficLights[edgeINum + nL] = 0x00;
-            else trafficLights[edgeINum + nL] = 0xFF;
+            if (intersections[i].isVertiport) {
+              // Vertiport: only green if pad capacity available
+              bool padAvailable = (intersections[i].vertiportCurrentOccupancy <
+                                   intersections[i].vertiportPadCapacity);
+              trafficLights[edgeINum + nL] = padAvailable ? 0xFF : 0x00;
+              if (padAvailable) {
+                intersections[i].vertiportCurrentOccupancy++;
+                intersections[i].vertiportQueueLength =
+                    max((int)intersections[i].vertiportQueueLength - 1, 0);
+              }
+            } else {
+              trafficLights[edgeINum + nL] = 0xFF;
+            }
           }
 
           break;

--- a/LivingCity/traffic/b18EdgeData.h
+++ b/LivingCity/traffic/b18EdgeData.h
@@ -44,9 +44,16 @@ struct B18IntersectionData {
   ushort state;
   ushort stateLine;
   ushort totalInOutEdges;
-  uint edge[28];// up to six arms intersection
+  uint edge[28];
   float nextEvent;
   bool isVertiport;
+
+  // Vertiport capacity modeling (only active when isVertiport == true)
+  ushort vertiportPadCapacity;    // max simultaneous takeoff/landing pads
+  ushort vertiportCurrentOccupancy; // vehicles currently on pads
+  ushort vertiportQueueLength;    // vehicles waiting for a pad
+  float  vertiportTurnoverTimeSec;  // time per takeoff/landing operation
+  float  vertiportLastDepartureTime; // for spacing enforcement
 };
 }
 


### PR DESCRIPTION
Closes #59. Vertiport intersections now enforce pad capacity constraints with queueing. UAM vehicles wait when all pads are occupied.